### PR TITLE
Update TreatmentPatterns version to accomodate maxPathLength

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -328,7 +328,7 @@
     },
     "TreatmentPatterns": {
       "Package": "TreatmentPatterns",
-      "Version": "3.0.0",
+      "Version": "3.0.2",
       "Source": "Repository",
       "Repository": "CRAN"
     },


### PR DESCRIPTION
The study json specification defines a maxPathLength of 7, which was not supported by [TreatmentPatterns](https://github.com/darwin-eu/TreatmentPatterns) until version 3.0.2 (see https://github.com/darwin-eu/TreatmentPatterns/commit/77864fe4ffdbdced1869bdc454e0f895f2157d23) 